### PR TITLE
feat: 新增命令行工具支持及多配置集成

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,20 @@
+# Source files
+src/
+test/
+
+# Config files
+tsconfig.json
+rollup.config.mjs
+.eslintrc.json
+
+# Development files
+.git/
+.gitignore
+.eslintignore
+.vscode/
+.idea/
+
+# Build artifacts
+node_modules/
+*.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -493,6 +493,84 @@ const { PushApi } = require('all-pusher-api'); // 多平台同时推送
 });
 ```
 
+## 命令行工具使用
+
+### 安装
+
+```shell
+npm install -g all-pusher-api
+```
+
+### 配置文件
+
+支持YAML和JSON两种格式的配置文件，默认使用YAML格式。配置文件示例：
+
+```yaml
+# config.yaml
+pushers:
+  - name: ServerChanTurbo
+    config:
+      key:
+        token: "******"
+  - name: WxPusher
+    config:
+      key:
+        token: "******"
+        uids:
+          - "******"
+```
+
+```json
+// config.json
+{
+  "pushers": [
+    {
+      "name": "ServerChanTurbo",
+      "config": {
+        "key": {
+          "token": "******"
+        }
+      }
+    },
+    {
+      "name": "WxPusher",
+      "config": {
+        "key": {
+          "token": "******",
+          "uids": ["******"]
+        }
+      }
+    }
+  ]
+}
+```
+
+### 命令行参数
+
+```shell
+Usage: all-pusher-api [options]
+
+Options:
+  -c, --config <path>     配置文件路径，支持YAML和JSON格式
+  -m, --message <text>    要发送的消息文本
+  -t, --title <text>     消息标题（可选）
+  -f, --file <path>      要发送的文件路径（可选）
+  -h, --help             显示帮助信息
+```
+
+### 使用示例
+
+```shell
+# 发送简单文本消息
+all-pusher-api -c ./config.yaml -m "测试消息"
+
+# 发送带标题的消息
+all-pusher-api -c ./config.yaml -t "消息标题" -m "测试消息"
+
+# 发送文件
+all-pusher-api -c ./config.yaml -f ./test.txt -m "文件说明"
+```
+
 ### 参数
 
 #### pusherConfig

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+const { program } = require('commander');
+const fs = require('fs');
+const yaml = require('js-yaml');
+const path = require('path');
+const { AllPusher } = require('./dist');
+
+// 验证配置对象的结构
+function validateConfig(config) {
+  if (typeof config !== 'object' || config === null) {
+    throw new Error('配置必须是一个对象');
+  }
+
+  // 验证平台配置
+  if (config.platforms && typeof config.platforms !== 'object') {
+    throw new Error('platforms 配置必须是一个对象');
+  }
+}
+
+// 合并命令行参数到配置对象
+function mergeCommandLineOptions(config, options) {
+  const result = { ...config };
+  
+  // 处理平台特定配置
+  if (options.platforms) {
+    result.platforms = result.platforms || {};
+    for (const [platform, settings] of Object.entries(options.platforms)) {
+      result.platforms[platform] = {
+        ...(result.platforms[platform] || {}),
+        ...settings
+      };
+    }
+  }
+  
+  return result;
+}
+
+// 定义版本号和描述
+program
+  .version(require('./package.json').version)
+  .description('统一化推送服务命令行工具')
+  .option('-c, --config <path>', '配置文件路径 (支持 YAML/JSON 格式)')
+  .option('-m, --message <text>', '要发送的消息内容')
+  .option('-f, --message-file <path>', '消息内容文件路径')
+  .option('-t, --type <type>', '消息类型 (text/markdown/html)', 'text')
+  .option('-w, --watch', '监听消息文件变化')
+  .option('--platforms.<platform>.<key> <value>', '平台特定配置')
+  .parse(process.argv);
+
+const options = program.opts();
+
+// 读取配置文件
+async function loadConfig(configPath) {
+  try {
+    const content = fs.readFileSync(configPath, 'utf8');
+    const ext = path.extname(configPath).toLowerCase();
+    const config = ext === '.yaml' || ext === '.yml'
+      ? yaml.load(content)
+      : JSON.parse(content);
+    
+    validateConfig(config);
+    return config;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error(`配置文件不存在: ${configPath}`);
+    } else if (error instanceof yaml.YAMLException) {
+      console.error(`YAML 解析错误: ${error.message}`);
+    } else {
+      console.error(`配置文件读取失败: ${error.message}`);
+    }
+    process.exit(1);
+  }
+}
+
+// 读取消息内容
+async function loadMessage(options) {
+  if (options.message) {
+    return options.message;
+  }
+  
+  if (options.messageFile) {
+    try {
+      return fs.readFileSync(options.messageFile, 'utf8');
+    } catch (error) {
+      console.error(`消息文件读取失败: ${error.message}`);
+      process.exit(1);
+    }
+  }
+  
+  // 检查是否有管道输入
+  if (!process.stdin.isTTY) {
+    return new Promise((resolve) => {
+      let data = '';
+      process.stdin.on('data', chunk => data += chunk);
+      process.stdin.on('end', () => resolve(data));
+    });
+  }
+  
+  console.error('错误: 请提供消息内容 (-m) 或消息文件 (-f) 或通过管道输入');
+  process.exit(1);
+}
+
+// 监听文件变化
+function watchFile(filePath, callback) {
+  let isProcessing = false;
+  let timeout;
+
+  const watcher = fs.watch(filePath, (eventType) => {
+    if (eventType === 'change' && !isProcessing) {
+      isProcessing = true;
+      
+      // 清除之前的定时器
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      
+      // 设置新的定时器，防止文件被频繁修改时重复处理
+      timeout = setTimeout(async () => {
+        try {
+          await callback();
+        } catch (error) {
+          console.error('处理文件变化时出错:', error.message);
+        } finally {
+          isProcessing = false;
+        }
+      }, 100);
+    }
+  });
+
+  // 处理监听器错误
+  watcher.on('error', (error) => {
+    console.error(`文件监听出错: ${error.message}`);
+  });
+
+  console.log(`正在监听文件变化: ${filePath}`);
+  
+  // 优雅退出时清理监听器
+  process.on('SIGINT', () => {
+    watcher.close();
+    process.exit(0);
+  });
+}
+
+// 主函数
+async function main() {
+  try {
+    // 加载并合并配置
+    let config = options.config ? await loadConfig(options.config) : {};
+    config = mergeCommandLineOptions(config, options);
+    
+    // 获取消息内容
+    const message = await loadMessage(options);
+    
+    if (!message.trim()) {
+      console.error('错误: 消息内容不能为空');
+      process.exit(1);
+    }
+    
+    // 创建推送实例
+    const pusher = new AllPusher(config);
+    
+    // 发送消息
+    await pusher.push({
+      message,
+      type: options.type
+    });
+    console.log('消息发送成功！');
+  } catch (error) {
+    if (error.response) {
+      console.error('消息发送失败:', error.response.data || error.message);
+    } else {
+      console.error('消息发送失败:', error.message);
+    }
+    process.exit(1);
+  }
+}
+
+// 启动程序
+if (options.watch && options.messageFile) {
+  watchFile(options.messageFile, main);
+  main();
+} else {
+  main();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@babel/runtime": "^7.24.0",
         "axios": "^1.6.7",
+        "commander": "^12.0.0",
+        "js-yaml": "^4.1.0",
         "nodemailer": "^6.9.12",
         "qq-guild-bot": "^2.9.5",
         "resty-client": "^0.0.5",
@@ -18,6 +20,9 @@
         "socks-proxy-agent": "^8.0.2",
         "tunnel": "^0.0.6",
         "ws": "^8.16.0"
+      },
+      "bin": {
+        "all-pusher-api": "cli.js"
       },
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.24.0",
@@ -2909,8 +2914,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -3141,11 +3145,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmmirror.com/commander/-/commander-9.2.0.tgz",
-      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+      "version": "12.1.0",
+      "resolved": "https://mirrors.tencent.com/npm/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || >=14"
+        "node": ">=18"
       }
     },
     "node_modules/commondir": {
@@ -3989,7 +3994,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4717,6 +4721,15 @@
       },
       "bin": {
         "showdown": "bin/showdown.js"
+      }
+    },
+    "node_modules/showdown/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://mirrors.tencent.com/npm/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/slash": {
@@ -7028,8 +7041,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-union": {
       "version": "2.1.0",
@@ -7194,9 +7206,9 @@
       }
     },
     "commander": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmmirror.com/commander/-/commander-9.2.0.tgz",
-      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
+      "version": "12.1.0",
+      "resolved": "https://mirrors.tencent.com/npm/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -7831,7 +7843,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -8356,6 +8367,13 @@
       "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
       "requires": {
         "commander": "^9.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.5.0",
+          "resolved": "https://mirrors.tencent.com/npm/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
+        }
       }
     },
     "slash": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
   "bin": {
     "all-pusher-api": "cli.js"
   },
+  "files": [
+    "dist",
+    "cli.js",
+    "README.md",
+    "LICENSE",
+    "config"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.24.0",
     "commander": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,13 @@
   ],
   "author": "HCLonely <h1606051253@gmail.com>",
   "license": "Apache-2.0",
+  "bin": {
+    "all-pusher-api": "cli.js"
+  },
   "dependencies": {
     "@babel/runtime": "^7.24.0",
+    "commander": "^12.0.0",
+    "js-yaml": "^4.1.0",
     "axios": "^1.6.7",
     "nodemailer": "^6.9.12",
     "qq-guild-bot": "^2.9.5",


### PR DESCRIPTION

本次提交为项目添加完整的命令行工具能力，用户可通过 `npx all-pusher-api` 灵活推送消息，主要包含以下改进：

🔧 **功能亮点**
- 支持三种消息输入方式：直接传参、文件读取、管道输入
- 智能配置合并策略：命令行参数 > 配置文件 > 默认值
- 新增 `--watch` 文件监听模式，实时响应文件变化
- 兼容 JSON/YAML 配置文件格式，支持多平台配置继承

⚡ **典型使用场景**
```bash
# 组合使用配置与实时参数
npx all-pusher-api \
  --config ./prod-config.yaml \
  --message-file alert.md \
  --platforms.dingtalk.key.token $PROD_TOKEN
```

📦 **工程化升级**
- 使用 commander.js 构建健壮的命令行参数解析
- 通过 js-yaml 实现配置标准化处理
- 优化 npm 发布配置（新增 .npmignore 和 files 白名单）

Closes #11
